### PR TITLE
Use github secret for image name.

### DIFF
--- a/.github/workflows/ci-build-test-publish.yml
+++ b/.github/workflows/ci-build-test-publish.yml
@@ -120,8 +120,8 @@ jobs:
           set -x
           root_dir=`pwd`
 
-          # Install AMWA test suite.  Use the bcp-006-01 branch
-          git clone -b bcp-006-01 https://github.com/AMWA-TV/nmos-testing.git
+          # Install AMWA test suite. 
+          git clone https://github.com/AMWA-TV/nmos-testing.git
           cd nmos-testing
 
           # Create output directories
@@ -133,7 +133,7 @@ jobs:
           pip install -r requirements.txt
 
           # Install SDPoker
-          npm install -g "git://github.com/AMWA-TV/sdpoker.git#bcp-006-01-rbg"
+          npm install -g git://github.com/AMWA-TV/sdpoker.git
           pip install -r utilities/run-test-suites/gsheetsImport/requirements.txt
 
       - name: Run AMWA Test suite against Node

--- a/.github/workflows/ci-build-test-publish.yml
+++ b/.github/workflows/ci-build-test-publish.yml
@@ -6,6 +6,8 @@ on:
 
   pull_request:
     branches: [dev, master]
+    
+  workflow_dispatch:
 
 env:
   SECRET_GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
@@ -70,7 +72,7 @@ jobs:
           dockerfile: Dockerfile
           publish: false
           load: true
-          imageName: rhastie/nmos-cpp
+          imageName: ${{ secrets.Docker_Image_Name }}
           tag: ${{ env.GITHUB_BRANCH }}
           buildArg: makemt=3
           platform: linux/amd64
@@ -108,7 +110,7 @@ jobs:
 
       - name: Start Node Docker container for Node tests
         working-directory: ${{ env.RUNNER_WORKSPACE }}
-        run: docker run -it -d --net=host --name nmos-cpp-node -v="$(pwd)/node.json:/home/node.json" -e "RUN_NODE=TRUE" rhastie/nmos-cpp:${{ env.GITHUB_BRANCH }}
+        run: docker run -it -d --net=host --name nmos-cpp-node -v="$(pwd)/node.json:/home/node.json" -e "RUN_NODE=TRUE" ${{ secrets.Docker_Image_Name }}:${{ env.GITHUB_BRANCH }}
 
       - name: Install AMWA Test suite
         shell: bash
@@ -118,8 +120,8 @@ jobs:
           set -x
           root_dir=`pwd`
 
-          # Install AMWA test suite.
-          git clone https://github.com/AMWA-TV/nmos-testing.git
+          # Install AMWA test suite.  Use the bcp-006-01 branch
+          git clone -b bcp-006-01 https://github.com/AMWA-TV/nmos-testing.git
           cd nmos-testing
 
           # Create output directories
@@ -131,8 +133,7 @@ jobs:
           pip install -r requirements.txt
 
           # Install SDPoker
-          npm install -g git+https://git@github.com/AMWA-TV/sdpoker.git
-
+          npm install -g "git://github.com/AMWA-TV/sdpoker.git#bcp-006-01-rbg"
           pip install -r utilities/run-test-suites/gsheetsImport/requirements.txt
 
       - name: Run AMWA Test suite against Node
@@ -184,9 +185,9 @@ jobs:
         run: |
           docker container stop nmos-cpp-node
           docker container rm nmos-cpp-node
-          docker run -it -d --net=host --name nmos-cpp-registry -v="$(pwd)/registry.json:/home/registry.json" -e "RUN_NODE=FALSE" rhastie/nmos-cpp:${{ env.GITHUB_BRANCH }}
+          docker run -it -d --net=host --name nmos-cpp-registry -v="$(pwd)/registry.json:/home/registry.json" -e "RUN_NODE=FALSE" ${{ secrets.Docker_Image_Name }}:${{ env.GITHUB_BRANCH }}
           sleep 5
-          docker run -it -d --net=host --name nmos-cpp-node -v="$(pwd)/node.json:/home/node.json" -e "RUN_NODE=TRUE" rhastie/nmos-cpp:${{ env.GITHUB_BRANCH }}
+          docker run -it -d --net=host --name nmos-cpp-node -v="$(pwd)/node.json:/home/node.json" -e "RUN_NODE=TRUE" ${{ secrets.Docker_Image_Name }}:${{ env.GITHUB_BRANCH }}
 
       - name: Run AMWA Test suite against Registry
         shell: bash
@@ -288,7 +289,7 @@ jobs:
           dockerfile: Dockerfile
           publish: true
           load: false
-          imageName: rhastie/nmos-cpp
+          imageName: ${{ secrets.Docker_Image_Name }}
           tag: ${{ env.BUILD_TAGS }}
           buildArg: makemt=3
           platform: ${{ env.BUILD_PLATFORMS }}
@@ -310,7 +311,7 @@ jobs:
       #   with:
       #     user: ${{ secrets.DockerHub_User }}
       #     pass: ${{ secrets.DockerHub_Password }}
-      #     slug: rhastie/nmos-cpp
+      #     slug: ${{ secrets.Docker_Image_Name }}
 
       - name: If Passes tests, build image file of x86 container
         if: env.TEST_FAIL == 'FALSE'
@@ -320,7 +321,7 @@ jobs:
           # Make directory and build image from container in Docker image repository
           mkdir container-image
           cd container-image
-          docker save rhastie/nmos-cpp:${{ env.GITHUB_BRANCH }}| gzip > nmos-cpp_${{ env.GITHUB_BRANCH }}-${{ env.GITHUB_COMMIT }}.img.tar.gz
+          docker save ${{ secrets.Docker_Image_Name }}:${{ env.GITHUB_BRANCH }}| gzip > nmos-cpp_${{ env.GITHUB_BRANCH }}-${{ env.GITHUB_COMMIT }}.img.tar.gz
 
       - name: If Passes tests, upload container image as an artifact
         if: env.TEST_FAIL == 'FALSE'


### PR DESCRIPTION
Using a github secret for the image name is a bit easier to maintain for forks of the repo and fits in with use of secrets for other items in the CI build.

Also added a workflow_dispatch so the build can be started manually.  Useful for situations when debugging the actual CI/CD workflow.