### PR TITLE
Bump nmos-js for Connection API Bridge client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ARG BASE_IMAGE=ubuntu:noble
-## Commit 079620d corresponds to Conan package nmos-cpp/cci.20260602
-ARG NMOS_CPP_VERSION=079620d88756aa138ede92d3f52a0102370307fe
-## IS-12 browser integration (sony/nmos-js#157) merged to master as of this commit
-ARG NMOS_JS_VERSION=17eacdaad298359cc10353944ab4f84413fcb190
+## Commit a19e364 corresponds to Conan package nmos-cpp/cci.20260812
+ARG NMOS_CPP_VERSION=a19e3648ecfd620715b0f0fe3f184c6b7f26a996
+## Tip of master including Connection API Bridge client + routing fixes (sony/nmos-js#171)
+ARG NMOS_JS_VERSION=7cb808218d059fb59b11b0be579437d55756d0e6
 
 ############################################################
 # Stage 1 — build nmos-cpp, certs, and assemble /home

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The following configuration, defined by the [ci-build-test-publish](.github/work
 
 | Base Container            | nmos-cpp Version                         | Test Runner          |
 |---------------------------|------------------------------------------|----------------------|
-| Ubuntu 24.04 (GCC 13.3.0) | `079620d` / cci.20260602 (mDNSResponder) | Ubuntu 24.04 (Avahi) |
+| Ubuntu 24.04 (GCC 13.3.0) | `a19e364` / cci.20260812 (mDNSResponder) | Ubuntu 24.04 (Avahi) |
 
 The [AMWA NMOS API Testing Tool](https://github.com/AMWA-TV/nmos-testing) is automatically run against the built **NMOS container** operating in both "nmos-node" and "nmos-registry" configurations.
 


### PR DESCRIPTION
## Summary
- Bump `NMOS_JS_VERSION` to commit `7cb8082` so the baked `/admin` UI includes Connection Bridge modes (No / Auto / Forced).
- Same nmos-js pin as [easy-nmos#37](https://github.com/rhastie/easy-nmos/pull/37).
- Confirmed existing `nmos-js.patch` still applies cleanly at this commit.

## Test plan
- [x] Docker build succeeds with the new `NMOS_JS_VERSION`
- [x] `/admin` Settings shows Connection Bridge control
- [x] Smoke against Easy-NMOS Envoy origin with Auto/Forced modes