### PR TITLE
Bump nmos-js to sony/master for NMOS Bridge and IS-08 edit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ARG BASE_IMAGE=ubuntu:noble
 ## Commit a19e364 corresponds to Conan package nmos-cpp/cci.20260812
 ARG NMOS_CPP_VERSION=a19e3648ecfd620715b0f0fe3f184c6b7f26a996
-## Tip of master including Connection API Bridge client + routing fixes (sony/nmos-js#171)
-ARG NMOS_JS_VERSION=7cb808218d059fb59b11b0be579437d55756d0e6
+## Tip of master including NMOS Bridge, IS-08 channel mapping edit, and NCP WebSockets
+ARG NMOS_JS_VERSION=182b3722cc9de04b2cb5ba60d1a09d5cf733bf30
 
 ############################################################
 # Stage 1 — build nmos-cpp, certs, and assemble /home

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Specifically the implementation supports the following specifications:
 Additionally it supports the following additional components:
 
 - Supports auto identification of the switch Boundary Clock PTP Domain which is published via the AMWA IS-09 System Resource when run on a Mellanox switch
-- Supports an embedded NMOS Browser Client/Controller which supports NMOS Control using AMWA IS-05. This implementation also supports AMWA IS-08 but currently view-only.
+- Supports an embedded NMOS Browser Client/Controller which supports NMOS Control using AMWA IS-05. This implementation also supports AMWA IS-08 Channel Mapping.
 - Supports an embedded MQTT Broker (mosquitto) to allow simplified use of the NMOS MQTT Transport type for AMWA IS-05 and IS-07 
 - Supports a DNS-SD Bridge to HTML implementation that supports both mDNS and DNS-SD
 


### PR DESCRIPTION
## Summary
- Pin `NMOS_JS_VERSION` to sony/nmos-js `182b3722` (current master: NMOS Bridge rename, IS-08 channel mapping edit, NCP WebSocket proxy).
- Drop the README "IS-08 view-only" note so it matches the new UI.

## Test plan
- [x] Image build with the new pin (`make build` / CI) succeeds and branding `nmos-js.patch` still applies.
- [ ] `/admin` Settings → Advanced shows NMOS Bridge Mode/API (not Connection Bridge).
- [ ] IS-08 channel mapping is editable in the controller.